### PR TITLE
README.md: fix mismatch between repo and app name in install instruct…

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ a dev dependency to your project's `mix.exs`:
 ```elixir
 defp deps do
   [
-    {:mix_bina, "~> 0.1", only: [:dev], runtime: false}
+    {:bina, "~> 0.1", only: [:dev, :test], runtime: false, git: "https://github.com/vinibrsl/mix_bina.git"}
   ]
 end
 ```


### PR DESCRIPTION
This change to the install instructions is required to use this module in another elixir project.

`mix_bina` specified `bina` as the [name of the app in mix.exs](https://github.com/vinibrsl/mix_bina/blob/main/mix.exs#L6).

That causes the module to be compiled as `bina.app`, rather than `mix_bina.app`, causing a mismatch if you add it as a dep using the name `mix_bina`. Instead, we can specify the package's home using the `git` argument to `deps`, allowing us to name the app `bina` without losing our ability to find the source.